### PR TITLE
Keep initial direction in subsequent events

### DIFF
--- a/src/thefinger.js
+++ b/src/thefinger.js
@@ -154,8 +154,9 @@ class TheFinger {
 
                 if (!this.#initialDirection) {
                     this.#initialDirection = this.#getDirection(this.#startX, this.#startY, x, y);
-                    data.initial_direction = this.#initialDirection;
                 }
+
+                data.initial_direction = this.#initialDirection;
 
                 this.#lastDragPayload = data;
                 this.#currentTouch = data;


### PR DESCRIPTION
When using requestAnimationFrame in event handlers, some events may be skipped. And sometimes it's an important data like initial_direction.

This fix passes it to every handler.